### PR TITLE
[Fix]Stage의 웨이브 시작단계에 else문 추가

### DIFF
--- a/Assets/WorkPlace/LJH/Scenes/Stage 3.unity
+++ b/Assets/WorkPlace/LJH/Scenes/Stage 3.unity
@@ -387,6 +387,7 @@ MonoBehaviour:
   _isAllMonsterSpawned: 0
   nextStageSceneName: Stage 4
   Upgrader: {fileID: 0}
+  _bossHp: {fileID: 0}
   mapBounds: {fileID: 2145998983}
   player: {fileID: 1986386511}
 --- !u!4 &1040837610
@@ -419,14 +420,14 @@ MonoBehaviour:
   groundPrefabs:
   - {fileID: 1537701171874230, guid: 22a52873015ef1645a73a4d0e9df39e4, type: 3}
   - {fileID: 1537701171874230, guid: 22a52873015ef1645a73a4d0e9df39e4, type: 3}
-  - {fileID: 1111494687657738, guid: ae09d9dd6effa2443bf54e95b908d708, type: 3}
-  - {fileID: 1111494687657738, guid: ae09d9dd6effa2443bf54e95b908d708, type: 3}
-  - {fileID: 1410631324709842, guid: 5e776800af408a34d8d89c702905f2d4, type: 3}
-  - {fileID: 1410631324709842, guid: 5e776800af408a34d8d89c702905f2d4, type: 3}
+  - {fileID: 1537701171874230, guid: 22a52873015ef1645a73a4d0e9df39e4, type: 3}
+  - {fileID: 1537701171874230, guid: 22a52873015ef1645a73a4d0e9df39e4, type: 3}
+  - {fileID: 1537701171874230, guid: 22a52873015ef1645a73a4d0e9df39e4, type: 3}
+  - {fileID: 1526646866334644, guid: a68d651cb81757343abbe1d39205eb96, type: 3}
+  - {fileID: 1526646866334644, guid: a68d651cb81757343abbe1d39205eb96, type: 3}
+  - {fileID: 1526646866334644, guid: a68d651cb81757343abbe1d39205eb96, type: 3}
   - {fileID: 1972576606893996, guid: ff3d32d8007f2e24595b8801e30989a4, type: 3}
   - {fileID: 1972576606893996, guid: ff3d32d8007f2e24595b8801e30989a4, type: 3}
-  - {fileID: 1681195754145498, guid: a44f9b5b803069b4ba7b244f59aac09c, type: 3}
-  - {fileID: 1681195754145498, guid: a44f9b5b803069b4ba7b244f59aac09c, type: 3}
   wallPrefab: {fileID: 1410631324709842, guid: 5e776800af408a34d8d89c702905f2d4, type: 3}
   lavaPrefab: {fileID: 1745447707790088, guid: 94b25f84ad255eb45ac650f2140605f6, type: 3}
   width: 100
@@ -434,7 +435,7 @@ MonoBehaviour:
   mapStartXPos: -101
   mapStartZPos: -101
   FloorPos: -1
-  nextStageSceneName: 
+  finalStage: 0
 --- !u!1 &1079208774
 GameObject:
   m_ObjectHideFlags: 0
@@ -598,6 +599,7 @@ MonoBehaviour:
   _isAllMonsterSpawned: 0
   nextStageSceneName: 
   Upgrader: {fileID: 0}
+  _bossHp: {fileID: 0}
   mapBounds: {fileID: 0}
   player: {fileID: 0}
 --- !u!4 &1151643224

--- a/Assets/WorkPlace/LJH/Scenes/Stage 4.unity
+++ b/Assets/WorkPlace/LJH/Scenes/Stage 4.unity
@@ -223,6 +223,7 @@ MonoBehaviour:
   _isAllMonsterSpawned: 0
   nextStageSceneName: 
   Upgrader: {fileID: 0}
+  _bossHp: {fileID: 0}
   mapBounds: {fileID: 0}
   player: {fileID: 0}
 --- !u!4 &81509357
@@ -766,6 +767,7 @@ MonoBehaviour:
   _isAllMonsterSpawned: 0
   nextStageSceneName: Stage 5
   Upgrader: {fileID: 0}
+  _bossHp: {fileID: 0}
   mapBounds: {fileID: 2023347218}
   player: {fileID: 1833919569}
 --- !u!4 &1700131485
@@ -796,11 +798,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   groundPrefabs:
-  - {fileID: 1410631324709842, guid: 5e776800af408a34d8d89c702905f2d4, type: 3}
-  - {fileID: 1410631324709842, guid: 5e776800af408a34d8d89c702905f2d4, type: 3}
-  - {fileID: 1410631324709842, guid: 5e776800af408a34d8d89c702905f2d4, type: 3}
-  - {fileID: 1410631324709842, guid: 5e776800af408a34d8d89c702905f2d4, type: 3}
+  - {fileID: 1537701171874230, guid: 22a52873015ef1645a73a4d0e9df39e4, type: 3}
+  - {fileID: 1537701171874230, guid: 22a52873015ef1645a73a4d0e9df39e4, type: 3}
   - {fileID: 1896491389295096, guid: 8e967992a76f5ff47ae189eff15e36c0, type: 3}
+  - {fileID: 1896491389295096, guid: 8e967992a76f5ff47ae189eff15e36c0, type: 3}
+  - {fileID: 1550454138371544, guid: 2794e957db1ec5a4a9b603ed0ea35ce4, type: 3}
+  - {fileID: 1550454138371544, guid: 2794e957db1ec5a4a9b603ed0ea35ce4, type: 3}
+  - {fileID: 1550454138371544, guid: 2794e957db1ec5a4a9b603ed0ea35ce4, type: 3}
+  - {fileID: 1550454138371544, guid: 2794e957db1ec5a4a9b603ed0ea35ce4, type: 3}
   wallPrefab: {fileID: 1295462230422698, guid: 13048acbe385bd14293b922ebc9ad23f, type: 3}
   lavaPrefab: {fileID: 1745447707790088, guid: 94b25f84ad255eb45ac650f2140605f6, type: 3}
   width: 100
@@ -808,7 +813,7 @@ MonoBehaviour:
   mapStartXPos: -101
   mapStartZPos: -101
   FloorPos: -1
-  nextStageSceneName: 
+  finalStage: 0
 --- !u!1 &1833919568
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/WorkPlace/LJH/Stage.cs
+++ b/Assets/WorkPlace/LJH/Stage.cs
@@ -114,7 +114,7 @@ public class Stage : MonoBehaviour
             else
             {
                 //좌표값 반환
-                return new Vector3(x, 1, z);
+                return new Vector3(x, 0, z);
             }
         }
 
@@ -176,7 +176,11 @@ public class Stage : MonoBehaviour
             Debug.Log($"{currentWaveIndex} 웨이브를 시작합니다.");
             StartCoroutine(SpawnWave());
         }
-        
+        else
+        {
+            currentWaveIndex--;
+        }
+
     }
 
     private void CreateMonster(Vector3 position, GameObject prefab)


### PR DESCRIPTION
Stage의 웨이브 시작단계에 else문 추가

몬스터 스폰위치 1 -> 0으로 수정

맵 큐브 4스테이지까지 선정