### PR TITLE
[Fix] 데미지를 업그레이드 할 때 뻥튀기 되는 현상을 수정

### DIFF
--- a/Assets/Script/Player/StatUpgrader.cs
+++ b/Assets/Script/Player/StatUpgrader.cs
@@ -54,7 +54,7 @@ public class StatUpgrader
                 EnhancedStatsInfo.EnhancedStatsDic["Speed"] += 20;
                 break;
             case Stats.Damage:
-                Manager.Player.Stats.Damage *= (int)(Manager.Player.Stats.Damage * 1.2f);
+                Manager.Player.Stats.Damage = (int)(Manager.Player.Stats.Damage * 1.2f);
                 EnhancedStatsInfo.EnhancedStatsDic["Damage"] += 20;
                 break;
             case Stats.InvincibleTime:


### PR DESCRIPTION
두번 곱하는 식이 되서 데미지가 뻥튀기 되는 현상을 수정