### PR TITLE
[Fix] ESC 버튼 연타시 일시정지 메뉴가 겹쳐서 나오던 현상 수정

### DIFF
--- a/Assets/Script/Manager/GameManager.cs
+++ b/Assets/Script/Manager/GameManager.cs
@@ -10,6 +10,12 @@ public class GameManager : Singleton<GameManager>
 {
     public event Action OnStartGame;
     public event Action OnGameOver;
+    public event Action<bool> OnPaused;
+
+    public void PauseGame(bool isPause)
+    {
+        OnPaused?.Invoke(isPause);
+    }
 
     public void StartGame()
     {

--- a/Assets/WorkPlace/YJH/Scripts/ESCtoPause.cs
+++ b/Assets/WorkPlace/YJH/Scripts/ESCtoPause.cs
@@ -7,11 +7,26 @@ public class EscapeKeyHandler : MonoBehaviour
 {
     [SerializeField] private Button targetButton;
 
+    private void OnEnable()
+    {
+        Manager.Game.OnPaused += OnPaused;
+    }
+
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (Input.GetKeyDown(KeyCode.Escape) && targetButton.interactable)
         {
             targetButton.onClick.Invoke(); // 버튼 눌리게 만듦
         }
+    }
+
+    private void OnDisable()
+    {
+        Manager.Game.OnPaused -= OnPaused;
+    }
+
+    private void OnPaused(bool isPause)
+    {
+        targetButton.interactable = !isPause;
     }
 }

--- a/Assets/WorkPlace/YJH/Scripts/Pause Menu Spawner.cs
+++ b/Assets/WorkPlace/YJH/Scripts/Pause Menu Spawner.cs
@@ -14,5 +14,6 @@ public class PauseMenuSpawner : MonoBehaviour
         Time.timeScale = 0f; // 일시정지 기능을 함. UI 제외한 물리 동작 등은 멈춤.
         GameObject spawnedBlocker = Instantiate(blocker, parentTransform); // 블로커 생성
         Instantiate(pauseMenu, parentTransform); // 일시정지 메뉴 팝업 생성
+        Manager.Game.PauseGame(true);
     }
 }

--- a/Assets/WorkPlace/YJH/Scripts/QuitCheckSpawner.cs
+++ b/Assets/WorkPlace/YJH/Scripts/QuitCheckSpawner.cs
@@ -9,6 +9,7 @@ public class QuitCheckSpawner : MonoBehaviour
     private string targetCanvasName = "UI_Canvas";
     public void SpawnQuitCheck()
     {
+        Manager.Game.PauseGame(false);
         GameObject canvasObj = GameObject.Find(targetCanvasName);
         GameObject spawnedBlocker = Instantiate(Blocker, canvasObj.transform); // 블로커 생성
         Instantiate(QuitPopup, canvasObj.transform);

--- a/Assets/WorkPlace/YJH/Scripts/Resume.cs
+++ b/Assets/WorkPlace/YJH/Scripts/Resume.cs
@@ -1,13 +1,17 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class Resume : MonoBehaviour
 {
     public GameObject targetToDestroy;
+
     public void ResumeGame()
     {
         Time.timeScale = 1f;
+        Manager.Game.PauseGame(false);
         Destroy(GameObject.FindWithTag("Blocker"));
         Destroy(targetToDestroy);
     }


### PR DESCRIPTION
일시정지 시 해당 버튼의 상호작용이 비활성화 되도록 구현하여 해당 오류를 해결하였습니다.