### PR TITLE
[Fix] 최대체력 증가 표기를 %로 변경

### DIFF
--- a/Assets/Script/Player/StatUpgrader.cs
+++ b/Assets/Script/Player/StatUpgrader.cs
@@ -14,7 +14,7 @@ public class StatUpgrader
         switch (stat)
         {
             case Stats.MaxHp:
-                return "최대 체력 10 증가";
+                return "최대 체력 10% 증가";
             case Stats.CurHp:
                 return "최대 체력으로 회복";
             case Stats.Speed:


### PR DESCRIPTION
10% 씩 증가하는 로직이기에 그에 맞춰 표기를 변경